### PR TITLE
Fix when looking up for a @BundleName

### DIFF
--- a/Assetic/Filter/CssURLRewriteFilter.php
+++ b/Assetic/Filter/CssURLRewriteFilter.php
@@ -52,7 +52,7 @@
 		public function checkForBundleLinking($path) {
 			if(substr($path, 0, 1) == '@') {
 				$findChar = strpos($path, '/');
-				$bundleName = substr($path, 1, $findChar);
+				$bundleName = substr($path, 1, $findChar-1);
 				try {
 					$bundle = $this->kernel->getBundle($bundleName);
 					return $this->calculateSwitchPath().'bundles/'.str_replace('_', '', $bundle->getContainerExtension()->getAlias()).substr($path, $findChar);


### PR DESCRIPTION
When you are searching for BundleName you have to remove the trailing / from the name.
There is a code for that but you must do -1 so it gets removed. 
