### PR TITLE
Fix file check if the url contains "?"

### DIFF
--- a/Assetic/Filter/CssURLRewriteFilter.php
+++ b/Assetic/Filter/CssURLRewriteFilter.php
@@ -123,8 +123,9 @@
 			if($lastChar=='"' || $lastChar=='\'') {
 				$url = substr($url, 0, -1);
 			}
-			
-			return file_exists($this->asset->getSourceRoot().'/'.dirname($this->asset->getSourcePath()).'/'.$url);
+
+			return file_exists($this->asset->getSourceRoot().'/'.dirname($this->asset->getSourcePath()).'/'.$url) ||
+				file_exists($this->asset->getSourceRoot().'/'.dirname($this->asset->getSourcePath()).'/'.strtok($url, '?'));
 		}
 		
 		public function normalizeUrl($url) {


### PR DESCRIPTION
The file check does not handle query parameters well - if the url contains one the file is not found and the asset is not rewritten. This fix tries to strip the "?" and rechecks the file.

By the way, I think that the configuration parameter "rewrite_if_file_exists" is miscalled. It should rather be a "rewrite_only_if_file_exists". Saves some looking in the doc ;)
