### PR TITLE
Fix filterDump failure on base64 encoded image

### DIFF
--- a/Assetic/Filter/CssURLRewriteFilter.php
+++ b/Assetic/Filter/CssURLRewriteFilter.php
@@ -41,6 +41,8 @@ class CssURLRewriteFilter implements FilterInterface
             $tmpPath = $that->checkForBundleLinking($matches[3]);
             if ($tmpPath != null) {
                 return $matches[1].'('.$matches[2].$tmpPath.')';
+            } elseif (substr($matches[3],0,5) == "data:") {
+                return $matches[1].'('.$matches[2].$matches[3].')';
             } elseif (!$that->checkPath($matches[3])) {
                 return $matches[1].'('.$matches[2].$matches[3].')';
             }


### PR DESCRIPTION
Hi,

The content of a css url directive could be a base64 encoded image. The
length of the string can be long. ( >4096). On some plateforms the
filename length is limited to less than 4096. In this case the function
filterDump fails because of using `file_exists` (in checkPath) on string
longer than 4096.

To prevent this, you need to check if the url directive begins with
"data:"

Please find attached patch.

Regards,
Philippe.